### PR TITLE
Add minimal support for creating an alto-clif multi command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,31 @@
+alto-clif
+===============
+[![Version](https://img.shields.io/npm/v/alto-clif.svg)](https://npmjs.org/package/alto-clif)
+[![License](https://img.shields.io/npm/l/alto-clif.svg)](https://github.com/bodawei/alto-clif/blob/master/package.json)
 
-<img src="https://user-images.githubusercontent.com/449385/38243295-e0a47d58-372e-11e8-9bc0-8c02a6f4d2ac.png" width="260" height="73">  
+### About
+This is a fork of [@oclif/oclif](https://github.com/oclif/oclif).
+The reason for this fork is to change this to allow one to create commands with space-separated
+subcommands rather than the heroku-style colon delimited.  This is a minimal change, which should
+allow this to be used with the rest of the `@oclif/*` system.
 
+### Notes/Next steps
+* This hasn't been particularly heavily tested, at this moment.
+* See alto-command for more details
+
+### Name explanation
+This is an alternate oclif, which is to say: "alt-oclif", which is to say "alto-clif".
+
+### Thanks
+
+Thanks to the [`@oclif` team and contributors](https://github.com/oclif/command/graphs/contributors).
+There are are lot of great ideas in oclif! Without them, of course, this package wouldn't exist!
+
+Original README info, below
+===============
 
 oclif: Node.JS Open CLI Framework
 =================================
-
-[![Join the chat at https://gitter.im/oclif/oclif](https://badges.gitter.im/oclif/oclif.svg)](https://gitter.im/oclif/oclif?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Version](https://img.shields.io/npm/v/oclif.svg)](https://npmjs.org/package/oclif)
-[![CircleCI](https://circleci.com/gh/oclif/oclif/tree/master.svg?style=shield)](https://circleci.com/gh/oclif/oclif/tree/master)
-[![Appveyor CI](https://ci.appveyor.com/api/projects/status/github/oclif/oclif?branch=master&svg=true)](https://ci.appveyor.com/project/heroku/oclif/branch/master)
-[![Downloads/week](https://img.shields.io/npm/dw/@oclif/command.svg)](https://npmjs.org/package/@oclif/command)
-[![License](https://img.shields.io/npm/l/oclif.svg)](https://github.com/oclif/oclif/blob/master/package.json)
 
 <!-- toc -->
 * [🗒 Description](#-description)

--- a/package.json
+++ b/package.json
@@ -1,18 +1,20 @@
 {
-  "name": "oclif",
-  "description": "oclif: create your own CLI",
-  "version": "1.12.6",
-  "author": "Jeff Dickey @jdxcode",
+  "name": "alto-clif",
+  "description": "Create an alto-clif CLI (fork of @oclif/oclif)",
+  "version": "0.9.0",
+  "author": "柏大衛",
+  "ocif-version": "1.13.2",
+  "oclif-author": "Jeff Dickey @jdxcode",
   "bin": "./bin/run",
-  "bugs": "https://github.com/oclif/oclif/issues",
+  "bugs": "https://github.com/bodawei/alto-clif/issues",
   "dependencies": {
-    "@oclif/command": "^1.5.6",
     "@oclif/config": "^1.9.0",
     "@oclif/errors": "^1.2.2",
     "@oclif/fixpack": "^2.3.0",
     "@oclif/plugin-help": "^2.1.4",
     "@oclif/plugin-not-found": "^1.2.2",
     "@oclif/plugin-warn-if-update-available": "^1.5.4",
+    "alto-command": "^0.9.1",
     "debug": "^4.1.0",
     "lodash": "^4.17.11",
     "nps-utils": "^1.7.0",
@@ -55,9 +57,10 @@
     "/lib",
     "/templates"
   ],
-  "homepage": "https://github.com/oclif/oclif",
+  "homepage": "https://github.com/bodawei/alto-clif",
   "keywords": [
-    "oclif"
+    "oclif",
+    "alto-clif"
   ],
   "license": "MIT",
   "main": "lib/index.js",
@@ -68,9 +71,9 @@
       "@oclif/plugin-warn-if-update-available",
       "@oclif/plugin-not-found"
     ],
-    "bin": "oclif"
+    "bin": "alto-clif"
   },
-  "repository": "oclif/oclif",
+  "repository": "bodawei/alto-clif",
   "scripts": {
     "lint": "nps lint",
     "postpack": "rm .oclif.manifest.json",

--- a/src/generators/app.ts
+++ b/src/generators/app.ts
@@ -444,7 +444,7 @@ class App extends Generator {
     case 'multi':
       dependencies.push(
           '@oclif/config@^1',
-          '@oclif/command@^1',
+          'alto-command@^0',
           '@oclif/plugin-help@^2',
         )
       devDependencies.push(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,1 @@
-export {run} from '@oclif/command'
+export {run} from 'alto-command'

--- a/templates/bin/run
+++ b/templates/bin/run
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
 
-require('@oclif/command').run()
+require('alto-command').run()
 .then(require('@oclif/command/flush'))
 .catch(require('@oclif/errors/handle'))

--- a/yarn.lock
+++ b/yarn.lock
@@ -59,7 +59,7 @@
     supports-color "^5.4.0"
     tslib "^1"
 
-"@oclif/command@^1.5.1", "@oclif/command@^1.5.10", "@oclif/command@^1.5.12", "@oclif/command@^1.5.13", "@oclif/command@^1.5.3", "@oclif/command@^1.5.6":
+"@oclif/command@^1.5.1", "@oclif/command@^1.5.10", "@oclif/command@^1.5.12", "@oclif/command@^1.5.13", "@oclif/command@^1.5.3":
   version "1.5.14"
   resolved "https://registry.yarnpkg.com/@oclif/command/-/command-1.5.14.tgz#cdf6013134abfb5630783f27e78436096ce3ed88"
   integrity sha512-R9gat0yUjamDVd4trvFgjlx2XYuMz1nM0uEBFP6nR1zOQAwJ3E1zqYbsVlCMWiUDGjU1hYmudmK7IjAxDUoqDw==
@@ -121,7 +121,7 @@
   resolved "https://registry.yarnpkg.com/@oclif/linewrap/-/linewrap-1.0.0.tgz#aedcb64b479d4db7be24196384897b5000901d91"
   integrity sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw==
 
-"@oclif/parser@^3.7.3":
+"@oclif/parser@3.8.1", "@oclif/parser@^3.7.3":
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/@oclif/parser/-/parser-3.8.1.tgz#3c842ef4a8ce3d1f5bcfa5938d3fbebf1c6a0618"
   integrity sha512-0OavFuLj6FBTdZDD6DXdNqH4qdLFLQD/PKK1OvNZhUd4/5v/lp6Ftzilwmirf549naNHq0u15uk1YCBvym5tNQ==
@@ -309,6 +309,16 @@ alce@1.2.0:
   dependencies:
     esprima "^1.2.0"
     estraverse "^1.5.0"
+
+alto-command@^0.9.1:
+  version "0.9.1"
+  resolved "https://registry.yarnpkg.com/alto-command/-/alto-command-0.9.1.tgz#e72e1adc4390b35f8f3f0d9b72b2ab4a74eceb24"
+  integrity sha512-1Xb+erk9iwbnrQ9io54cZ+Mb+eW1ppb5XYiQ98nrcyltsA+qfG2Z5kuGzAavYEEd8K01bhKt/ZDlS+AURMm3fQ==
+  dependencies:
+    "@oclif/errors" "^1.2.2"
+    "@oclif/parser" "3.8.1"
+    debug "^4.1.1"
+    semver "^5.6.0"
 
 ansi-escapes@^3.1.0, ansi-escapes@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
This fork of @oclif/oclif creates a "multi" command that uses alto-command. That, in turn, allows one to specify subcommands with spaces rather than colons between them.