### PR TITLE
fix(typescript): Fix type definition for typescript command definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "alto-clif",
   "description": "Create an alto-clif CLI (fork of @oclif/oclif)",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "author": "柏大衛",
   "ocif-version": "1.13.4",
   "oclif-author": "Jeff Dickey @jdxcode",

--- a/templates/src/command.ts.ejs
+++ b/templates/src/command.ts.ejs
@@ -16,7 +16,7 @@ hello world from ./src/<%- name %>.ts!
   ]
 
 <%_ } _%>
-  static flags = {
+  static flags: flags.Input<any> = {
 <%_ if (type === 'single') { _%>
     // add --version flag to show CLI version
     version: flags.version({char: 'v'}),


### PR DESCRIPTION
### BUG
Some tests for the multi command using typescript were failing.  This was because of a typescript error:
```
src/commands/hello.ts(12,10): error TS2742: The inferred type of 'flags' cannot be named without a reference to 'alto-command/node_modules/@oclif/parser/lib/flags'. This is likely not portable. A type annotation is necessary.
```

### DETAILS
This was, actually, a baffling error. If I replaced the reference to `alto-command` with `@oclif/command`, the error would vanish. The two packages are essentially identical. Perhaps there's some indirect reference to @oclif/command in one of the dependencies and so things aren't quite meshing.

However, as I investigated further, I found that the types in a pure oclif system do not work correctly.  Consider 
```
    const foo: flags.IFlag<string> = {. // where flags is the import from @oclif/command
      type: 'boolean',
      allowNo: false,
      name: 'fred',
      parse: (input: boolean, context: any) => { return 'hi' }
    };
```
This is, according to typescript a reasonable declaration.  However, I can take the exact same thing and put into the static flags:
```
  static flags = {
    foo4: {
      type: 'boolean',
      allowNo: false,
      name: 'fred',
      parse: (input: boolean, context: any) => { return 'hi' }
    },

```
an I get another typescript error about properties not being correct. Which I believe is not right.  Alternately, you can take the the output from something like `flags.boolean({char: 'f'})` and insert that into the static flags declaration, and you'll get another error (even though, obviously, that should be correct).  This suggests to me that the types around this static flags declaration has some problems.  Note that the declaration of `static flags` in `@oclif/command` is `static flags?: flags.Input<any>;`, whee that `any` is pretty strange (since that is used to drive some of the type parameterization in the Input and Output types).  Again, it currently seems like the various types here are not declared quite right in oclif.

### FIX
This "fixes" the problem by modifying the typescript template to make the type of `static flags` explicit (`static flags: flags.Input<any> = ...`).  I don't find this satisfying, but I can't justify the time to untangle and rewrite the types in oclif now.

